### PR TITLE
Updated arch to alpha5 and fixed an issue with the TypeConverters.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,12 +59,12 @@ dependencies {
     compile rootProject.ext.supportLibCardview
 
     //arch-comp Lifecycles, LiveData, and ViewModel
-    compile "android.arch.lifecycle:runtime:1.0.0-alpha1"
-    compile "android.arch.lifecycle:extensions:1.0.0-alpha1"
-    kapt "android.arch.lifecycle:compiler:1.0.0-alpha1"
+    compile "android.arch.lifecycle:runtime:1.0.0-alpha5"
+    compile "android.arch.lifecycle:extensions:1.0.0-alpha5"
+    kapt "android.arch.lifecycle:compiler:1.0.0-alpha5"
     //arch-comp Room
-    compile "android.arch.persistence.room:runtime:1.0.0-alpha1"
-    kapt "android.arch.persistence.room:compiler:1.0.0-alpha1"
+    compile "android.arch.persistence.room:runtime:1.0.0-alpha5"
+    kapt "android.arch.persistence.room:compiler:1.0.0-alpha5"
 
     //di
     compile rootProject.ext.dagger

--- a/app/src/main/kotlin/com/generalmobile/app/gmnotes/db/converters/DateConverter.kt
+++ b/app/src/main/kotlin/com/generalmobile/app/gmnotes/db/converters/DateConverter.kt
@@ -11,7 +11,7 @@ class DateConverter {
     }
 
     @TypeConverter
-    fun dateToTimestamp(date: Date?): Long {
-        return date?.time ?: 0L
+    fun dateToTimestamp(date: Date?): Long? {
+        return date?.time
     }
 }


### PR DESCRIPTION
Newer versions need the two TypeConverter methods to have the same types to compile.
Took me a while to understand why it wouldn't compile, so I'm sending this PR to help someone else looking for this.